### PR TITLE
Log using RCF3339 timestamps

### DIFF
--- a/src/acm.c
+++ b/src/acm.c
@@ -237,14 +237,18 @@ void acm_write(int level, const char *format, ...)
 {
 	va_list args;
 	struct timeval tv;
+	struct tm tmtime;
+	char buffer[20];
 
 	if (level > log_level)
 		return;
 
 	gettimeofday(&tv, NULL);
+	localtime_r(&tv.tv_sec, &tmtime);
+	strftime(buffer, 20, "%Y-%m-%dT%H:%M:%S", &tmtime);
 	va_start(args, format);
 	lock_acquire(&log_lock);
-	fprintf(flog, "%u.%03u: ", (unsigned) tv.tv_sec, (unsigned) (tv.tv_usec / 1000));
+	fprintf(flog, "%s.%03u: ", buffer, (unsigned) (tv.tv_usec / 1000));
 	vfprintf(flog, format, args);
 	fflush(flog);
 	lock_release(&log_lock);


### PR DESCRIPTION
Unix timestamps are great for computers, but not so great for humans.  RFC3339 format looks like `2018-02-25T15:27:41.091`

Signed-off-by: Matt Ezell <ezellma@ornl.gov>